### PR TITLE
Fixes for showing custom workouts on Wahoo headunit

### DIFF
--- a/mrc/mrc.py
+++ b/mrc/mrc.py
@@ -35,7 +35,7 @@ class Mrc:
         for line in raw_course_text.split("\n"):
             if line == "":
                 continue
-            
+
             try:
                 messages.append(MrcMessage.from_raw_course_text(line))
             except ValueError:

--- a/mrc_to_wahoo_plan.py
+++ b/mrc_to_wahoo_plan.py
@@ -19,6 +19,12 @@ def get_wahoo_intervals(mrc):
 
 def mrc_to_wahoo_plan(mrc, name=None, description=None):
     builder = WahooPlan.Builder()
+
+    if not name:
+        name, _ = os.path.splitext(mrc.course_header.file_name)
+    if not description:
+        description = mrc.course_header.description
+
     builder.set_name(name).set_description(description)
 
     for interval in get_wahoo_intervals(mrc):
@@ -39,7 +45,5 @@ if __name__ == "__main__":
         print("mrc has no PERCENT or FTP data type")
         quit()
 
-    root, _ = os.path.splitext(filename)
-    name = os.path.basename(root)
     with open(filename.strip("mrc") + "plan", "w") as f:
-        f.write(str(mrc_to_wahoo_plan(mrc, name)))
+        f.write(str(mrc_to_wahoo_plan(mrc)))

--- a/mrc_to_wahoo_plan.py
+++ b/mrc_to_wahoo_plan.py
@@ -1,6 +1,7 @@
 from mrc.mrc import Mrc
 from wahoo_plan.wahoo_plan import WahooPlan, WahooInterval
 import sys
+import os
 
 def get_wahoo_intervals(mrc):
     wahoo_intervals = []
@@ -19,7 +20,7 @@ def get_wahoo_intervals(mrc):
 def mrc_to_wahoo_plan(mrc, name=None, description=None):
     builder = WahooPlan.Builder()
     builder.set_name(name).set_description(description)
-    
+
     for interval in get_wahoo_intervals(mrc):
         builder.add_interval(interval)
 
@@ -38,5 +39,7 @@ if __name__ == "__main__":
         print("mrc has no PERCENT or FTP data type")
         quit()
 
+    root, _ = os.path.splitext(filename)
+    name = os.path.basename(root)
     with open(filename.strip("mrc") + "plan", "w") as f:
-        f.write(str(mrc_to_wahoo_plan(mrc)))
+        f.write(str(mrc_to_wahoo_plan(mrc, name)))

--- a/wahoo_plan/wahoo_plan.py
+++ b/wahoo_plan/wahoo_plan.py
@@ -100,6 +100,11 @@ class WahooPlan:
     def __init__(self):
         self.name = None
         self.duration = 0
+
+        # LOCATION_TYPE and WORKOUT_TYPE, see:
+        # https://gist.github.com/Intyre/2c0a8e337671ed6f523950ef08e3ca3f?permalink_comment_id=4688536#gistcomment-4688536
+        self.location_type = 0
+        self.workout_type = 0
         self.description = None
         self.ftp_test_factor = None
 
@@ -111,7 +116,9 @@ class WahooPlan:
             output += "NAME={}\n".format(self.name)
 
         output += "DURATION={}\n".format(self.duration)
-        
+        output += "LOCATION_TYPE={}\n".format(self.location_type)
+        output += "WORKOUT_TYPE={}\n".format(self.workout_type)
+
         if self.description is not None:
             for line in textwrap.wrap(self.description, 96):
                 output += "DESCRIPTION={} \n".format(line)


### PR DESCRIPTION
Fixes the following known issues with uploading workouts:

- **Missing plan files**: Displays `.plan` workout files
- **Uploaded workouts all named "SD PLAN"**: Shows the name and description under Planned Workouts